### PR TITLE
Add interceptor feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "example",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "program": "dart_log_example.dart",
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+[2022-05-25]
+### Added
+- interceptor feature
+
 ## 1.1.1
 [2022-01-30]
 ### Chore

--- a/README.md
+++ b/README.md
@@ -44,3 +44,12 @@ logger.d('long response from API', maxChars: 10000);
 // default = 3
 logger.d('Link to file', fileLinkLevel: 3);
 ```
+
+#### Interceptors 
+Use the `DefaultLogInterceptor` or implement a custom `LogInterceptor`
+
+```dart
+Logger.interceptors.add(DefaultLogInterceptor((Object? data) {
+    print('ERROR: $data');
+}, logTypes: [LogType.error]));
+```

--- a/example/dart_log_example.dart
+++ b/example/dart_log_example.dart
@@ -1,5 +1,27 @@
+import 'dart:developer';
+
 import 'package:dart_log/dart_log.dart';
 
-void main() {
-  logger.d('message');
+void main() async {
+  Logger.prefix = '';
+  Logger.interceptors.add(DefaultLogInterceptor((Object? data) {
+    log('** Interceptor ($data) **');
+  }));
+
+  Logger.interceptors.add(DefaultLogInterceptor((Object? data) {
+    print('\x1B[31mONLY ERROR: $data\x1B[0m');
+  }, logTypes: [LogType.error]));
+
+  Logger.interceptors.add(DefaultLogInterceptor((Object? data) {
+    print('\x1B[33mWARNING OR INFO: $data\x1B[0m');
+  }, logTypes: [LogType.warn, LogType.info]));
+
+  logger.d('"debug message"');
+  logger.e('"error message"');
+  logger.i('"info message"');
+  logger.w('"warn message"');
+  logger.trace('"trace message"', stackTrace: StackTrace.current);
+  logger.prod('"prod message"');
+
+  await Future.delayed(Duration.zero);
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: example
+description: example project
+version: 1.0.0
+homepage: https://github.com/emanuel-braz/dart_log
+publish_to: none
+
+environment:
+  sdk: '>=2.15.1 <3.0.0'
+
+dependencies:
+  dart_log: 
+    path: ../

--- a/lib/dart_log.dart
+++ b/lib/dart_log.dart
@@ -1,3 +1,5 @@
 library dart_log;
 
+export 'src/enums/types.dart';
+export 'src/log_interceptor.dart';
 export 'src/logger.dart';

--- a/lib/src/enums/types.dart
+++ b/lib/src/enums/types.dart
@@ -1,0 +1,9 @@
+enum LogType {
+  debug,
+  error,
+  info,
+  warn,
+  trace,
+  file,
+  prod,
+}

--- a/lib/src/log_interceptor.dart
+++ b/lib/src/log_interceptor.dart
@@ -1,0 +1,20 @@
+import 'enums/types.dart';
+
+abstract class LogInterceptor {
+  void log(Object? data, LogType logType);
+}
+
+class DefaultLogInterceptor implements LogInterceptor {
+  final List<LogType> logTypes;
+  final void Function(Object? data) onLog;
+
+  DefaultLogInterceptor(this.onLog, {this.logTypes = const <LogType>[]});
+
+  @override
+  void log(Object? data, LogType logType) {
+    if (logTypes.isEmpty || logTypes.isNotEmpty && logTypes.contains(logType)) {
+      final message = '${logType.name}: ${data.toString().trimLeft()}';
+      onLog(message);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_log
 description: A simple dart console logger (release mode enabled/disabled and "limitless" characters)
-version: 1.1.1
+version: 1.2.0
 homepage: https://github.com/emanuel-braz/dart_log
 
 environment:


### PR DESCRIPTION
## Release 1.2.0
[2022-05-25]
### Added
- interceptor feature

#### Interceptors 
Use the `DefaultLogInterceptor` or implement a custom `LogInterceptor`

```dart
Logger.interceptors.add(DefaultLogInterceptor((Object? data) {
    print('ERROR: $data');
}, logTypes: [LogType.error]));
```